### PR TITLE
Correct late deductions late.java

### DIFF
--- a/src/main/java/late.java
+++ b/src/main/java/late.java
@@ -7,10 +7,10 @@ public class late {
     int minutes = Integer.parseInt(timeParts[1]);
     // Employee's are given 10 minutes grace period
 
-    if (hours == 8 && minutes > 11){ //for morning [8:00 - 8:10]
+    if (hours == 8 && minutes > 10){ //for morning [8:00 - 8:10]
       return 1;
     }
-    else if (hours == 1 && minutes > 11){ //for afternoon [1:00 - 1:10]
+    else if (hours == 1 && minutes > 10){ //for afternoon [1:00 - 1:10]
       return 1;
     }
     switch (hours){


### PR DESCRIPTION
If {minutes > 11}, it doesn't return a deduction of 1 if time is 8:11.

If {minutes > 10}, it returns a deduction of 1 if time is 8:11.

Based on my understanding, there would be no deduction if time is 8:00-8:10 and 1:00-1:10. 
But if it exceeds (ex. 8:11 or 1:11, there will be deductions?)